### PR TITLE
fix: 테스트에서 실제 서버 의존성 제거

### DIFF
--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,12 +1,12 @@
 spring.config.name=dev
 
-spring.rabbitmq.host=${RABBITMQ_HOST}
-spring.rabbitmq.port=${RABBITMQ_PORT}
-spring.rabbitmq.username=${RABBITMQ_USERNAME}
-spring.rabbitmq.password=${RABBITMQ_PW}
-spring.rabbitmq.template.exchange=${RABBITMQ_EXCHANGE}
-spring.rabbitmq.template.routing-key=${RABBITMQ_ROUTINGKEY}
+spring.rabbitmq.host=localhost
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=test
+spring.rabbitmq.password=test
+spring.rabbitmq.template.exchange=test
+spring.rabbitmq.template.routing-key=test
 
-mqtt.server.uri=${MQTT_URI}
-mqtt.client.id=${MQTT_ID}
-mqtt.subscribe.topic=${MQTT_TOPIC}
+mqtt.server.uri=localhost
+mqtt.client.id=test
+mqtt.subscribe.topic=#

--- a/src/test/java/org/example/bridgeserver/BridgeServerApplicationTests.java
+++ b/src/test/java/org/example/bridgeserver/BridgeServerApplicationTests.java
@@ -1,13 +1,17 @@
 package org.example.bridgeserver;
 
+import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 @SpringBootTest
 class BridgeServerApplicationTests {
 
+    @MockBean
+    MqttClient mqttClient;
+
     @Test
     void contextLoads() {
     }
-
 }


### PR DESCRIPTION
테스트 시 실제 서버에 연결하기 때문에 CI/CD 과정에서 문제가 발생합니다.
해결을 위해 클라이언트 객체를 모킹하여 의존성을 배제했습니다.